### PR TITLE
Make Rack::Cors lint-compliant

### DIFF
--- a/lib/rack/cors.rb
+++ b/lib/rack/cors.rb
@@ -5,6 +5,7 @@ module Rack
     ENV_KEY = 'rack.cors'.freeze
 
     ORIGIN_HEADER_KEY     = 'HTTP_ORIGIN'.freeze
+    ORIGIN_X_HEADER_KEY   = 'HTTP_X_ORIGIN'.freeze
     PATH_INFO_HEADER_KEY  = 'PATH_INFO'.freeze
     VARY_HEADER_KEY       = 'Vary'.freeze
     DEFAULT_VARY_HEADERS  = ['Origin'].freeze
@@ -45,7 +46,7 @@ module Rack
     end
 
     def call(env)
-      env[ORIGIN_HEADER_KEY] ||= env['HTTP_X_ORIGIN']
+      env[ORIGIN_HEADER_KEY] ||= env[ORIGIN_X_HEADER_KEY] if env[ORIGIN_X_HEADER_KEY]
 
       add_headers = nil
       if env[ORIGIN_HEADER_KEY]

--- a/test/unit/cors_test.rb
+++ b/test/unit/cors_test.rb
@@ -272,6 +272,21 @@ describe Rack::Cors do
     end
   end
 
+  describe 'Rack::Lint' do
+    def app
+      @app ||= Rack::Builder.new do
+        use Rack::Cors
+        use Rack::Lint
+        run ->(env) { [200, {'Content-Type' => 'text/html'}, ['hello']] }
+      end
+    end
+
+    it 'is lint-compliant with non-CORS request' do
+      get '/'
+      last_response.status.must_equal 200
+    end
+  end
+
   protected
     def cors_request(*args)
       path = args.first.is_a?(String) ? args.first : '/'

--- a/test/unit/test.ru
+++ b/test/unit/test.ru
@@ -1,6 +1,7 @@
 require 'rack/cors'
 
 #use Rack::Cors, :debug => true, :logger => ::Logger.new(STDOUT) do
+use Rack::Lint
 use Rack::Cors do
   allow do
     origins 'localhost:3000', '127.0.0.1:3000', /http:\/\/192\.168\.0\.\d{1,3}(:\d+)?/, 'file://'


### PR DESCRIPTION
Only use X-ORIGIN when defined.

Setting ORIGIN header to nil makes Rack::Lint fail.